### PR TITLE
Get objects by key

### DIFF
--- a/DX.Data.Xpo/XpoDtoDatasource.cs
+++ b/DX.Data.Xpo/XpoDtoDatasource.cs
@@ -235,7 +235,7 @@ namespace DX.Data.Xpo.Identity
 			{
 				foreach (var item in items)
 				{
-					TXPOEntity dbItem = wrk.FindObject<TXPOEntity>(CriteriaOperator.Parse("[Id]==?", item.Key));
+					TXPOEntity dbItem = wrk.GetObjectByKey<TXPOEntity>(item.Key);
 					if (dbItem == null)
 					{
 						if (insertOnNotFound)
@@ -281,7 +281,7 @@ namespace DX.Data.Xpo.Identity
 
 			using (UnitOfWork wrk = database.GetUnitOfWork())
 			{
-				wrk.Delete(new XPCollection(wrk, typeof(TXPOEntity), new InOperator("Id", (from o in items select o.Key).ToArray()), null));
+				wrk.Delete(wrk.GetObjectsByKey(wrk.GetClassInfo<TXPOEntity>(), (from o in items select o.Key).ToArray(), false));
 				wrk.CommitChanges();
 			}
 		}


### PR DESCRIPTION
I have changed two places where objects are loaded by key.
I's better to user UnitOfWork.GetObjectByKey and UnitOfWork.GetObjectsByKey methods, because the do it optimally.
It may be worth to improve it in the same way in other places.
Thanks!
