### PR TITLE
Add type conversion when using Guid as TKey

### DIFF
--- a/DX.Data.Xpo.Identity/XPUserStore.cs
+++ b/DX.Data.Xpo.Identity/XPUserStore.cs
@@ -320,7 +320,8 @@ namespace DX.Data.Xpo.Identity
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			ThrowIfDisposed();
-			var result = await FindByIdAsync(userId);
+			var id = System.ComponentModel.TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromString(userId);
+			var result = await FindByIdAsync(id);
 			return result;
 		}
 
@@ -422,7 +423,7 @@ namespace DX.Data.Xpo.Identity
 			await DB.ExecuteAsync((db, wrk) =>
 			{
 				wrk.Delete(wrk.FindObject(typeof(TXPOLogin),
-						 CriteriaOperator.Parse("([User!Key] == ?) AND (LoginProvider == ?) AND )ProviderKey == ?)",
+						 CriteriaOperator.Parse("([User!Key] == ?) AND (LoginProvider == ?) AND (ProviderKey == ?)",
 														 user.Id, login.LoginProvider, login.ProviderKey)));
 				//return 0;
 			});

--- a/DX.Data.Xpo.Identity/XPUserStore.cs
+++ b/DX.Data.Xpo.Identity/XPUserStore.cs
@@ -194,7 +194,8 @@ namespace DX.Data.Xpo.Identity
 
 			var result = await DB.ExecuteAsync((db, wrk) =>
 			{
-				var xpoUser = wrk.FindObject(XPOUserType, CriteriaOperator.Parse("Logins[(LoginProvider == ?) AND (ProviderKey == ?)]", loginProvider, providerKey));
+				var xpoLogin = (TXPOLogin)wrk.FindObject(XPOLoginType, CriteriaOperator.Parse("(LoginProvider == ?) AND (ProviderKey == ?)", loginProvider, providerKey));
+				var xpoUser = xpoLogin == null ? null : wrk.GetObjectByKey(XPOUserType, xpoLogin.UserId);
 
 				//return xpoUser == null ? null : Activator.CreateInstance(typeof(TUser), xpoUser, DxIdentityUserFlags.FLAG_FULL) as TUser;
 				return (xpoUser == null) ? null : Mapper.CreateModel(xpoUser as TXPOUser);


### PR DESCRIPTION
I got an error when using Guid as TKey
> An unhandled exception occurred while processing the request.
> InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Guid'.
> DX.Data.Xpo.Identity.XPUserStore<TKey, TUser, TXPOUser, TXPORole, TXPOLogin, TXPOClaim, TXPOToken>.FindByIdAsync(object userId) in XPUserStore.cs, line 484
> 
> System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Guid'.
>    at DX.Data.Xpo.Identity.XPUserStore`7.FindByIdAsync(Object userId) in C:\Source\NextFunnel\DXWeb\DX.Data.Xpo.Identity\XPUserStore.cs:line 484
>    at DX.Data.Xpo.Identity.XPUserStore`7.FindByIdAsync(String userId, CancellationToken cancellationToken) in C:\Source\NextFunnel\DXWeb\DX.Data.Xpo.Identity\XPUserStore.cs:line 323
>    at Microsoft.AspNetCore.Identity.SignInManager`1.ValidateSecurityStampAsync(ClaimsPrincipal principal)
>    at Microsoft.AspNetCore.Identity.SecurityStampValidator`1.ValidateAsync(CookieValidatePrincipalContext context)
>    at Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler.HandleAuthenticateAsync()
>    at Microsoft.AspNetCore.Authentication.AuthenticationHandler`1.AuthenticateAsync()
>    at Microsoft.AspNetCore.Authentication.AuthenticationService.AuthenticateAsync(HttpContext context, String scheme)
>    at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
>    at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)